### PR TITLE
Add "has_consented", remove "subscribe_to_newsletter" from auth/register parameters

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -85,16 +85,13 @@ class MediaCloud(object):
             'password': password,
             'full_name': full_name,
             'notes': notes,
+            'has_consented': has_consented,
             'subscribe_to_newsletter': subscribe_to_newsletter,
             'activation_url': activation_url,
         }
         _validate_bool_params(params, 'subscribe_to_newsletter')
+        _validate_bool_params(params, 'has_consented')
         results = self._queryForJson(self.V2_API_URL+'auth/register', params, 'POST')
-        # hack to add `has_consented` because auth/register endpoint doesn't support it (for now)
-        if ('success' in results) and (results['success'] == 1):
-            if 'has_consented':
-                user = self.userList(search=email)['users'][0]
-                self.userUpdate(auth_users_id=user['auth_users_id'], has_consented=has_consented)
         return results
 
     def authActivate(self, email, activation_token):

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -78,7 +78,7 @@ class MediaCloud(object):
         }
         return self._queryForJson(self.V2_API_URL+'auth/login', params, 'POST')
 
-    def authRegister(self, email, password, full_name, notes, subscribe_to_newsletter, activation_url, has_consented):
+    def authRegister(self, email, password, full_name, notes, activation_url, has_consented):
         # :return: {success: 1}, or {error: "msg"}
         params = {
             'email': email,
@@ -86,10 +86,8 @@ class MediaCloud(object):
             'full_name': full_name,
             'notes': notes,
             'has_consented': has_consented,
-            'subscribe_to_newsletter': subscribe_to_newsletter,
             'activation_url': activation_url,
         }
-        _validate_bool_params(params, 'subscribe_to_newsletter')
         _validate_bool_params(params, 'has_consented')
         results = self._queryForJson(self.V2_API_URL+'auth/register', params, 'POST')
         return results


### PR DESCRIPTION
Hi @rahulbot!

Could you merge & deploy this one real quick? After my updates to `auth/register`, it now *requires* `has_consented` to be set explicitly, so the new user registration isn't currently working:

<img width="927" alt="Screenshot 2019-11-06 at 19 10 40" src="https://user-images.githubusercontent.com/181949/68293566-2c4ea700-00c9-11ea-94b6-86e633f18837.png">

Additionally, I've removed `subscribe_to_newsletter` flag which was removed on the backend.